### PR TITLE
Removed POSIX dependency

### DIFF
--- a/fast_obj.h
+++ b/fast_obj.h
@@ -263,20 +263,23 @@ unsigned int file_read(void* file, void* dst, unsigned int bytes)
 
 
 static
-unsigned int file_size(void* file)
+unsigned long file_size(void* file)
 {
     FILE* f;
-    off_t p;
-    off_t n;
+    long p;
+    long n;
     
     f = (FILE*)(file);
 
-    p = ftello(f);
-    fseeko(f, 0, SEEK_END);
-    n = ftello(f);
-    fseeko(f, p, SEEK_SET);
+    p = ftell(f);
+    fseek(f, 0, SEEK_END);
+    n = ftell(f);
+    fseek(f, p, SEEK_SET);
 
-    return (unsigned int)(n);
+    if (n > 0)
+        return (unsigned long)(n);
+    else
+        return 0;
 }
 
 
@@ -873,7 +876,7 @@ const char* read_map(fastObjData* data, const char* ptr, fastObjTexture* map)
 static
 int read_mtllib(fastObjData* data, void* file)
 {
-    unsigned int    n;
+    unsigned long   n;
     const char*     s;
     char*           contents;
     unsigned int    l;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -48,7 +48,8 @@ static
 bool read_tiny_obj(const char* path, tinyObj* o)
 {
     std::string err;
-    return LoadObj(&o->attrib, &o->shapes, &o->materials, &err, path, 0, false);
+    std::string warn;
+    return LoadObj(&o->attrib, &o->shapes, &o->materials, &warn, &err, path, 0, false);
 }
 
 


### PR DESCRIPTION
fast_obj wouldn't build on Windows because `fseeko` and `ftello` seem to be part of POSIX, not the standard library. I changed these to `fseek` and `ftell`, and it will now build on Windows.

Additionally, I updated the demo program for the tinyobj v1.3 api, which had breaking changes.