### PR TITLE
Fix .obj parsing when empty 'g' is last

### DIFF
--- a/fast_obj.h
+++ b/fast_obj.h
@@ -1153,6 +1153,9 @@ void parse_buffer(fastObjData* data, const char* ptr, const char* end)
             case 'n':
                 p = parse_normal(data, p);
                 break;
+
+            default:
+                p--; /* roll p++ back in case *p was a newline */
             }
             break;
 
@@ -1165,6 +1168,9 @@ void parse_buffer(fastObjData* data, const char* ptr, const char* end)
             case '\t':
                 p = parse_face(data, p);
                 break;
+
+            default:
+                p--; /* roll p++ back in case *p was a newline */
             }
             break;
 
@@ -1177,6 +1183,9 @@ void parse_buffer(fastObjData* data, const char* ptr, const char* end)
             case '\t':
                 p = parse_group(data, p);
                 break;
+
+            default:
+                p--; /* roll p++ back in case *p was a newline */
             }
             break;
 


### PR DESCRIPTION
In some .obj files, there's a stray 'g' followed by a newline at the
very end of the file. What happens right now is that *p++ skips past the
"terminating newline", and then proceeds to process out of bounds memory
which leads to a crash.

I'm not sure if 'g' can actually be empty per spec, so this change just
fixes the crash without resetting the group to "default" or anything
like that; 'v'/'f' shouldn't be empty but this would fix crashing when
parsing malicious/malformed .obj files as well.