### PR TITLE
Fix bump map parsing

### DIFF
--- a/fast_obj.h
+++ b/fast_obj.h
@@ -1076,7 +1076,7 @@ int read_mtllib(fastObjData* data, void* file)
                          p[3] == 'p' &&
                          is_whitespace(p[4]))
                 {
-                    p = read_map(data, p + 4, &mtl.map_d);
+                    p = read_map(data, p + 4, &mtl.map_bump);
                 }
             }
             break;


### PR DESCRIPTION
Hi, very small change - it looks like the parser currently uses the wrong field when reading in the bump map texture.