### PR TITLE
Fix buffer overflow in string_equal

### DIFF
--- a/fast_obj.h
+++ b/fast_obj.h
@@ -349,10 +349,10 @@ char* string_concat(const char* a, const char* s, const char* e)
 static
 int string_equal(const char* a, const char* s, const char* e)
 {
-    while (*a++ == *s++ && s != e)
-        ;
+    size_t an = strlen(a);
+    size_t sn = (size_t)(e - s);
 
-    return (*a == '\0' && s == e);
+    return an == sn && memcmp(a, s, an) == 0;
 }
 
 


### PR DESCRIPTION
When string_equal's first argument is a prefix of the second argument
but the second argument is longer, the loop goes through all characters
of the first string, compares terminating NUL with a different character
in the right hand side string, discovers that it's different and leaves
the loop - with 'a' having already been incremented.

After this the condition proceeds to read from *a which causes a buffer
overrun.

Fix this by changing the function to something that's obviously correct,
even if somewhat less efficient.