### PR TITLE
Fix memcpy with overlapping regions

### DIFF
--- a/fast_obj.h
+++ b/fast_obj.h
@@ -1367,7 +1367,7 @@ fastObjMesh* fast_obj_read(const char* path)
 
         /* Copy overflow for next buffer */
         bytes = (unsigned int)(end - last);
-        memcpy(buffer, last, bytes);
+        memmove(buffer, last, bytes);
         start = buffer + bytes;
     }
 


### PR DESCRIPTION
When moving the unprocessed line to the beginning of the buffer, in rare
edge cases where the unprocessed chunk is larger than the processed
chunks (which means the lines are very long), the source & target range
will overlap. This is undefined as per C standard and triggers ubsan
errors.

Fix this by using memmove.