### PR TITLE
Adds big obj files support

### DIFF
--- a/fast_obj.h
+++ b/fast_obj.h
@@ -70,12 +70,18 @@ typedef struct
 
 } fastObjMaterial;
 
+/* Allows user override to bigger indexable array */
+#ifndef FAST_OBJ_UINT_TYPE
+#define FAST_OBJ_UINT_TYPE unsigned int
+#endif
+
+typedef FAST_OBJ_UINT_TYPE fastObjUInt;
 
 typedef struct
 {
-    unsigned int                p;
-    unsigned int                t;
-    unsigned int                n;
+	fastObjUInt                p;
+	fastObjUInt                t;
+	fastObjUInt                n;
 
 } fastObjIndex;
 
@@ -198,8 +204,7 @@ double POWER_10_NEG[MAX_POWER] =
 };
 
 
-static
-void* memory_realloc(void* ptr, size_t bytes)
+static void* memory_realloc(void* ptr, fastObjUInt bytes)
 {
     return FAST_OBJ_REALLOC(ptr, bytes);
 }
@@ -218,7 +223,7 @@ void memory_dealloc(void* ptr)
 #define array_capacity(_arr)    ((_arr) ? _array_capacity(_arr) : 0)
 #define array_empty(_arr)       (array_size(_arr) == 0)
 
-#define _array_header(_arr)     ((unsigned int*)(_arr) - 2)
+#define _array_header(_arr)     ((fastObjUInt*)(_arr)-2)
 #define _array_size(_arr)       (_array_header(_arr)[0])
 #define _array_capacity(_arr)   (_array_header(_arr)[1])
 #define _array_ngrow(_arr, _n)  ((_arr) == 0 || (_array_size(_arr) + (_n) >= _array_capacity(_arr)))
@@ -226,21 +231,20 @@ void memory_dealloc(void* ptr)
 #define _array_grow(_arr, _n)   (*((void**)&(_arr)) = array_realloc(_arr, _n, sizeof(*(_arr))))
 
 
-static
-void* array_realloc(void* ptr, unsigned int n, unsigned int b)
+static void* array_realloc(void* ptr, fastObjUInt n, fastObjUInt b)
 {
-    unsigned int  sz   = array_size(ptr);
-    unsigned int  nsz  = sz + n;
-    unsigned int  cap  = array_capacity(ptr);
-    unsigned int  ncap = 3 * cap / 2;
-    unsigned int* r;
+	fastObjUInt sz = array_size(ptr);
+	fastObjUInt nsz = sz + n;
+	fastObjUInt cap = array_capacity(ptr);
+	fastObjUInt ncap = 3 * cap / 2;
+	fastObjUInt* r;
 
 
     if (ncap < nsz)
         ncap = nsz;
     ncap = (ncap + 15) & ~15u;
 
-    r = (unsigned int*)(memory_realloc(ptr ? _array_header(ptr) : 0, b * ncap + 2 * sizeof(unsigned int)));
+    r = (fastObjUInt*)(memory_realloc(ptr ? _array_header(ptr) : 0, b * ncap + 2 * sizeof(fastObjUInt)));
     if (!r)
         return 0;
 
@@ -669,21 +673,21 @@ const char* parse_face(fastObjData* data, const char* ptr)
         }
 
         if (v < 0)
-            vn.p = (array_size(data->mesh->positions) / 3) - (unsigned int)(-v);
+			vn.p = (array_size(data->mesh->positions) / 3) - (fastObjUInt)(-v);
         else
-            vn.p = (unsigned int)(v);
+            vn.p = (size_t)(v);
 
         if (t < 0)
-            vn.t = (array_size(data->mesh->texcoords) / 2) - (unsigned int)(-t);
+			vn.t = (array_size(data->mesh->texcoords) / 2) - (fastObjUInt)(-t);
         else if (t > 0)
-            vn.t = (unsigned int)(t);
+            vn.t = (size_t)(t);
         else
             vn.t = 0;
 
         if (n < 0)
-            vn.n = (array_size(data->mesh->normals) / 3) - (unsigned int)(-n);
+			vn.n = (array_size(data->mesh->normals) / 3) - (fastObjUInt)(-n);
         else if (n > 0)
-            vn.n = (unsigned int)(n);
+			vn.n = (fastObjUInt)(n);
         else
             vn.n = 0;
 
@@ -1266,9 +1270,9 @@ fastObjMesh* fast_obj_read(const char* path)
     char*        start;
     char*        end;
     char*        last;
-    unsigned int read;
-    size_t       sep;
-    unsigned int bytes;
+	fastObjUInt  read;
+	size_t       sep;
+	fastObjUInt  bytes;
 
 
     /* Open file */
@@ -1327,7 +1331,7 @@ fastObjMesh* fast_obj_read(const char* path)
     for (;;)
     {
         /* Read another buffer's worth from file */
-        read = (unsigned int)(file_read(file, start, BUFFER_SIZE));
+		read = (fastObjUInt)(file_read(file, start, BUFFER_SIZE));
         if (read == 0 && start == buffer)
             break;
 
@@ -1366,7 +1370,7 @@ fastObjMesh* fast_obj_read(const char* path)
 
 
         /* Copy overflow for next buffer */
-        bytes = (unsigned int)(end - last);
+		bytes = (fastObjUInt)(end - last);
         memmove(buffer, last, bytes);
         start = buffer + bytes;
     }


### PR DESCRIPTION
Problem: on a 22gb file, it fails on "out of bound write" in the arary_size/mgrow/ngrow macros

Fix: using size_t on 64bits for arithmetic ptr alloc/index system fixes it