### PR TITLE
Fix MSVC /W4 warning

### DIFF
--- a/fast_obj.h
+++ b/fast_obj.h
@@ -203,7 +203,7 @@ double POWER_10_NEG[MAX_POWER] =
 };
 
 
-static void* memory_realloc(void* ptr, fastObjUInt bytes)
+static void* memory_realloc(void* ptr, size_t bytes)
 {
     return FAST_OBJ_REALLOC(ptr, bytes);
 }


### PR DESCRIPTION
Conversion from size_t to unsigned int is lossy.