### PR TITLE
Add support for name with spaces

### DIFF
--- a/fast_obj.h
+++ b/fast_obj.h
@@ -405,6 +405,11 @@ int is_whitespace(char c)
     return (c == ' ' || c == '\t' || c == '\r');
 }
 
+static
+int is_end_of_name(char c)
+{
+    return (c == '\t' || c == '\r' || c == '\n');
+}
 
 static
 int is_newline(char c)
@@ -722,7 +727,7 @@ const char* parse_group(fastObjData* data, const char* ptr)
     ptr = skip_whitespace(ptr);
 
     s = ptr;
-    while (!is_whitespace(*ptr) && !is_newline(*ptr))
+    while (!is_end_of_name(*ptr))
         ptr++;
 
     e = ptr;
@@ -803,7 +808,7 @@ const char* parse_usemtl(fastObjData* data, const char* ptr)
 
     /* Parse the material name */
     s = ptr;
-    while (!is_whitespace(*ptr) && !is_newline(*ptr))
+    while (!is_end_of_name(*ptr))
         ptr++;
 
     e = ptr;
@@ -901,7 +906,7 @@ const char* read_map(fastObjData* data, const char* ptr, fastObjTexture* map)
 
     /* Read name */
     s = ptr;
-    while (!is_whitespace(*ptr) && !is_newline(*ptr))
+    while (!is_end_of_name(*ptr))
         ptr++;
 
     e = ptr;
@@ -977,7 +982,7 @@ int read_mtllib(fastObjData* data, void* file)
                     p++;
 
                 s = p;
-                while (!is_whitespace(*p) && !is_newline(*p))
+                while (!is_end_of_name(*p))
                     p++;
 
                 mtl.name = string_copy(s, p);
@@ -1120,7 +1125,7 @@ const char* parse_mtllib(fastObjData* data, const char* ptr)
     ptr = skip_whitespace(ptr);
 
     s = ptr;
-    while (!is_whitespace(*ptr) && !is_newline(*ptr))
+    while (!is_end_of_name(*ptr))
         ptr++;
 
     e = ptr;
@@ -1404,4 +1409,3 @@ fastObjMesh* fast_obj_read(const char* path)
 }
 
 #endif
-


### PR DESCRIPTION
if a name or a filepath has "spaces" in it, and "first part" of the name is similar to another it makes name matching fails

```
mtl my material
mtl my material 2
```

Then at https://github.com/thisistherk/fast_obj/blob/master/fast_obj.h#L822 previous code would always match on "my" name of material.

Texture under filepath with space in it failed too before.
