### PR TITLE
Create materials even if not definition provided

### DIFF
--- a/fast_obj.h
+++ b/fast_obj.h
@@ -820,12 +820,6 @@ const char* parse_usemtl(fastObjData* data, const char* ptr)
 
     e = ptr;
 
-
-    /* If there are no materials yet, add a dummy invalid material at index 0 */
-    if (array_empty(data->mesh->materials))
-        array_push(data->mesh->materials, mtl_default());
-
-
     /* Find an existing material with the same name */
     idx = 0;
     while (idx < array_size(data->mesh->materials))
@@ -837,8 +831,14 @@ const char* parse_usemtl(fastObjData* data, const char* ptr)
         idx++;
     }
 
+    /* If doesn't exists, create a default one with this name
+    Note: this case happens when OBJ doesn't have its MTL */
     if (idx == array_size(data->mesh->materials))
-        idx = 0;
+    {
+        fastObjMaterial new_mtl = mtl_default();
+        new_mtl.name = string_copy(s, e);
+        array_push(data->mesh->materials, new_mtl);
+    }
 
     data->material = idx;
 


### PR DESCRIPTION
**Problem:** 
I read a bare OBJ so no MTL is provided. I still want to keep the materials setup across the scene for further edit.

**Fix:** 
Instead of using a fallback material (idx 0), create a material for each 'not-defined' material while keeping the name so that the structure of the model is conserved.

**Question:** the comment `If there are no materials yet, add a dummy invalid material at index` suggests that in some cases a material can be used before it's definition. I didn't see anything preventing this to happen, and the update I'm suggesting will not give the right result in this case. 

Here is an example:
``` 
usemtl material
{geom definition}

mtllib asset.mtl
usemtl material
{geom definition}
```

(In this case, the output will have both geometries linked to the default material `material`, loosing the actual definition)

