### PR TITLE
Trim trailing whitespaces from mtllib definitions

### DIFF
--- a/fast_obj.h
+++ b/fast_obj.h
@@ -1198,6 +1198,10 @@ const char* parse_mtllib(fastObjData* data, const char* ptr, const fastObjCallba
     e = ptr;
 
     lib = string_concat(data->base, s, e);
+
+    while (lib[strlen(lib) - 1] == ' ')
+        lib[strlen(lib) - 1] = '\0';
+
     if (lib)
     {
         string_fix_separators(lib);


### PR DESCRIPTION
It seems some obj exporters leave a trailing whitespace after the `mtllib` declaration. This commit simply checks and removes trailing whitespaces from that lib path. 

Im not sure this is an appropriate solution for the lib as im not sure if this issues is too specific to my situation. Also I did not check if trailing whitespaces can become an issue in other parts. 

Nonetheless, somebody else might run into this so I decided to share. 