### PR TITLE
Fix 32-bit integer overflow issues

### DIFF
--- a/fast_obj.h
+++ b/fast_obj.h
@@ -265,15 +265,14 @@ static void* array_realloc(void* ptr, fastObjUInt n, fastObjUInt b)
     fastObjUInt sz = array_size(ptr);
     fastObjUInt nsz = sz + n;
     fastObjUInt cap = array_capacity(ptr);
-    fastObjUInt ncap = 3 * cap / 2;
+    fastObjUInt ncap = cap + cap / 2;
     fastObjUInt* r;
-
 
     if (ncap < nsz)
         ncap = nsz;
     ncap = (ncap + 15) & ~15u;
 
-    r = (fastObjUInt*)(memory_realloc(ptr ? _array_header(ptr) : 0, b * ncap + 2 * sizeof(fastObjUInt)));
+    r = (fastObjUInt*)(memory_realloc(ptr ? _array_header(ptr) : 0, (size_t)b * ncap + 2 * sizeof(fastObjUInt)));
     if (!r)
         return 0;
 


### PR DESCRIPTION
When an array reached a size that would require >4GB allocation, the argument to realloc would overflow during multiplication, resulting in a very small allocation and a subsequent out of bounds access.

This change fixes that and also adjusts capacity calculation so that it doesn't overflow 32-bit range until it's basically impossible not to.

This is not perfect - in particular, on 32-bit systems there's a risk of size_t overflow that remains, however because we grow in 1.5x increments, realistically an attempt to grow a 2GB allocation to the next increment would fail before that. We can also technically overflow capacity even after the adjustment, but that requires 3+B elements which effectively means an .obj file on the scale of hundreds of gigabytes, at which point maybe a streaming parser would be more practical.