### PR TITLE
Mark materials that weren't loaded from mtllib as fallback

### DIFF
--- a/fast_obj.h
+++ b/fast_obj.h
@@ -65,6 +65,9 @@ typedef struct
     float                       d;      /* Disolve (alpha) */
     int                         illum;  /* Illumination model */
 
+    /* Set for materials that don't come from the associated mtllib */
+    int                         fallback;
+
     /* Texture maps */
     fastObjTexture              map_Ka;
     fastObjTexture              map_Kd;
@@ -323,7 +326,7 @@ unsigned long file_size(void* file, void* user_data)
     long p;
     long n;
     (void)(user_data);
-        
+
     f = (FILE*)(file);
 
     p = ftell(f);
@@ -872,6 +875,8 @@ fastObjMaterial mtl_default(void)
     mtl.d     = 1.0;
     mtl.illum = 1;
 
+    mtl.fallback = 0;
+
     mtl.map_Ka   = map_default();
     mtl.map_Kd   = map_default();
     mtl.map_Ks   = map_default();
@@ -919,6 +924,7 @@ const char* parse_usemtl(fastObjData* data, const char* ptr)
     {
         fastObjMaterial new_mtl = mtl_default();
         new_mtl.name = string_copy(s, e);
+        new_mtl.fallback = 1;
         array_push(data->mesh->materials, new_mtl);
     }
 


### PR DESCRIPTION
This can happen when mtllib is absent, points to a non-existing file, or material names are incorrect. In either case it helps the reader differentiate between materials that are actually specified in the file, even if their definition happens to match the default, from materials that were never loaded in the first place.